### PR TITLE
Subscription e-mail changed url link

### DIFF
--- a/CateringNotification/Content/Campus/Campus.cs
+++ b/CateringNotification/Content/Campus/Campus.cs
@@ -10,7 +10,7 @@ namespace CateringNotification.Content.Campus
     {
         internal static async Task<string> GetMenuAsync(string url)
         {
-            return "<div><p>" + string.Join("</p><p>", await GetMenuItemsAsync(url)) + "</p></div>";
+            return "<div style=\" text-align: center;\"><h1  style=\"color: #58A518;\">Het menu van vandaag is:</h1><hr><p style=\"font-family: impact; font-size: 18px;\">" + string.Join("</p><p style=\"font-family: impact; font-size: 18px;\">", await GetMenuItemsAsync(url)) + "</p></div>";
         }
 
         private static async Task<IEnumerable<string>> GetMenuItemsAsync(string url)

--- a/CateringNotification/Content/Campus/Campus.cs
+++ b/CateringNotification/Content/Campus/Campus.cs
@@ -10,7 +10,12 @@ namespace CateringNotification.Content.Campus
     {
         internal static async Task<string> GetMenuAsync(string url)
         {
-            return "<div style=\" text-align: center;\"><h1  style=\"color: #58A518;\">Het menu van vandaag is:</h1><hr><p style=\"font-family: impact; font-size: 18px;\">" + string.Join("</p><p style=\"font-family: impact; font-size: 18px;\">", await GetMenuItemsAsync(url)) + "</p></div>";
+            return
+                "<div style=\" text-align: center;\">" +
+                "<h1  style=\"color: #58A518;\">Het menu van vandaag is:</h1><hr>" +
+                "<p style=\"font-family: impact; font-size: 18px;\">" +
+                string.Join("</p><p style=\"font-family: impact; font-size: 18px;\">", await GetMenuItemsAsync(url)) +
+                "</p></div>";
         }
 
         private static async Task<IEnumerable<string>> GetMenuItemsAsync(string url)

--- a/CateringNotification/Functions/Subscription.cs
+++ b/CateringNotification/Functions/Subscription.cs
@@ -91,7 +91,7 @@ namespace CateringNotification.Functions
 
             await Mail.SendMailAsync(new List<string>(new[] {subscription.Email}), 
                 "Catering Notification - Bevestiging verandering",
-                "Je hebt je inschrijving succesvol veranderd! Indien je de uren van de emails wilt aanpassen, kan je altijd opnieuw inschrijven op https://www.pxlfood.be/ .");
+                "Je hebt je inschrijving succesvol veranderd! Indien je de uren van de emails wilt aanpassen, kan je altijd opnieuw inschrijven op <a href=\"https://www.pxlfood.be/ \">pxlfood.be</a>.");
 
             return new OkResult();
         }

--- a/CateringNotification/Functions/Subscription.cs
+++ b/CateringNotification/Functions/Subscription.cs
@@ -36,8 +36,8 @@ namespace CateringNotification.Functions
             var verificationToken = await Verification.SetVerify(email);
 
             await Mail.SendMailAsync(new List<string>(new[] {subscription.Email}),
-                "Catering Notification - Bevestigig inschrijving",
-                $"Gebruik de code {verificationToken} om je inschrijving op de dagelijkse email van de catering te updaten of te activeren. Deze kan je ingeven op https://www.pxlfood.be/verify?email={subscription.Email} .");
+                "Catering Notification - Bevestiging inschrijving",
+                $"<p>Gebruik de code <strong>{verificationToken}</strong> om je inschrijving op de dagelijkse e-mail van de catering te updaten of te activeren. Deze kan je ingeven op<a href=\"https://www.pxlfood.be/verify?email={subscription.Email} \">pxlfood.be</a>.</p>");
 
             return new OkResult();
         }

--- a/CateringNotification/Functions/Subscription.cs
+++ b/CateringNotification/Functions/Subscription.cs
@@ -37,7 +37,7 @@ namespace CateringNotification.Functions
 
             await Mail.SendMailAsync(new List<string>(new[] {subscription.Email}),
                 "Catering Notification - Bevestiging inschrijving",
-                $"<p>Gebruik de code <strong>{verificationToken}</strong> om je inschrijving op de dagelijkse e-mail van de catering te updaten of te activeren. Deze kan je ingeven op<a href=\"https://www.pxlfood.be/verify?email={subscription.Email} \">pxlfood.be</a>.</p>");
+                $"<p>Gebruik de code <strong>{verificationToken}</strong> om je inschrijving op de dagelijkse e-mail van de catering te updaten of te activeren. Deze kan je ingeven op <a href=\"https://www.pxlfood.be/verify?email={subscription.Email} \">pxlfood.be</a>.</p>");
 
             return new OkResult();
         }
@@ -62,7 +62,7 @@ namespace CateringNotification.Functions
 
             await Mail.SendMailAsync(new List<string>(new[] {subscription.Email}),
                 "Catering Notification - Bevestig uitschrijving",
-                $"Gebruik de code {verificationToken} om je inschrijving op de dagelijkse email van de catering op te zeggen. Deze kan je ingeven op https://www.pxlfood.be/verify?email={subscription.Email} .");
+                $"<p>Gebruik de code <strong>{verificationToken}</strong> om je inschrijving op de dagelijkse email van de catering op te zeggen. Deze kan je ingeven op <a href=\"https://www.pxlfood.be/verify?email={subscription.Email}\">pxlfood.be</a>.</p>");
 
             return new OkResult();
         }

--- a/build-azure-pipelines.yml
+++ b/build-azure-pipelines.yml
@@ -25,17 +25,17 @@ steps:
     rootFolderOrFile: '$(System.DefaultWorkingDirectory)/functions'
     archiveFile: '$(Build.ArtifactStagingDirectory)/functions/$(Build.BuildId).zip'
     includeRootFolder: false
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: $(Build.ArtifactStagingDirectory)/functions
+    artifactName: functions
 - script: |
     cd web
     tsc main.ts -t ES2019
 - task: CopyFiles@2
   inputs:
     contents: 'web/**'
-    targetFolder: $(System.DefaultWorkingDirectory)/web/
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: $(Build.ArtifactStagingDirectory)/functions
-    artifactName: functions
+    targetFolder: $(Build.ArtifactStagingDirectory)/web/
 - task: PublishBuildArtifacts@1
   inputs:
     pathToPublish: $(Build.ArtifactStagingDirectory)/web


### PR DESCRIPTION
The subscription email had a plain text url link in it, which might have caused it to automatically to been sent to the spam folder. Now the link will be represented in a anchor tag. This might resolve the issue.